### PR TITLE
Add ternary support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,11 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.2.tgz",
       "integrity": "sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA=="
     },
+    "@types/parse5": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.0.tgz",
+      "integrity": "sha512-J5D3z703XTDIGQFYXsnU9uRCW9e9mMEFO0Kpe6kykyiboqziru/RlZ0hM2P+PKTG4NHG1SjLrqae/NrV2iJApQ=="
+    },
     "ansi-colors": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
@@ -734,6 +739,16 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
+    },
+    "parse5": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+      "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
+    },
+    "parse5-traverse": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/parse5-traverse/-/parse5-traverse-1.0.3.tgz",
+      "integrity": "sha512-+gvNpmU91iJBjNrzvmhSSSf0B5bcWBYE1Eex8HrvnOrCMtzHPBKiy8MhFb2Li77AYwNErLiB4Mjfx97Me07+Pg=="
     },
     "path-exists": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   "license": "ISC",
   "dependencies": {
     "@types/node": "^12.0.2",
+    "@types/parse5": "^5.0.0",
+    "parse5": "^5.1.0",
+    "parse5-traverse": "^1.0.3",
     "source-map-support": "^0.5.12",
     "strip-indent": "^3.0.0",
     "ts-simple-type": "^0.3.4",

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -249,6 +249,63 @@ suite('grimlock', () => {
         });
       }
 
+      test('text ternary', () => {
+        const result = convertModule(
+          'test.ts',
+          js`
+        import {html} from 'lit-html';
+
+        /**
+         * @soyCompatible
+         */
+        export const t = (yes: boolean) => html\`
+          <div>\${yes
+            ? html\`<p>yes</p>\`
+            : html\`<p>no</p>\`
+          }</div>\`;
+      `
+        );
+        assert.equal(
+          result.output,
+          soy`
+          {namespace test.ts}
+
+          {template .t}
+            {@param yes: bool}
+          
+            <div>{if $yes}<p>yes</p>{else}<p>no</p>{/if}</div>
+          {/template}
+        `
+        );
+      });
+
+      test('expression ternary', () => {
+        const result = convertModule(
+          'test.ts',
+          js`
+        import {html} from 'lit-html';
+
+        /**
+         * @soyCompatible
+         */
+        export const t = (yes: boolean) => html\`
+          <div>\${1 + (yes ? 1 : 2)}</div>\`;
+      `
+        );
+        assert.equal(
+          result.output,
+          soy`
+          {namespace test.ts}
+
+          {template .t}
+            {@param yes: bool}
+          
+            <div>{1+($yes?1:2)}</div>
+          {/template}
+        `
+        );
+      });
+
       test(`error on strict equality`, () => {
         const result = convertModule(
           'test.ts',


### PR DESCRIPTION
Not really ready for review until #9 review comments are addressed, but an initial hack in getting ternary support. Highlights some of the trickiness in deal with a lit-html expression that could emit either a Soy expression or a command. This is a limitation in the emit-while-analyzing approach of the prototype.