### PR TITLE
Add a Soy AST and separate emit phase.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -175,6 +175,11 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -405,8 +410,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "invert-kv": {
       "version": "2.0.0",
@@ -461,6 +465,11 @@
       "requires": {
         "has-symbols": "^1.0.0"
       }
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isexe": {
       "version": "2.0.0",
@@ -545,6 +554,14 @@
         "map-age-cleaner": "^0.1.1",
         "mimic-fn": "^2.0.0",
         "p-is-promise": "^2.0.0"
+      }
+    },
+    "memory-streams": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/memory-streams/-/memory-streams-0.1.3.tgz",
+      "integrity": "sha512-qVQ/CjkMyMInPaaRMrwWNDvf6boRZXaT/DbQeMYcCWuXPEBf1v8qChOc9OlEVQp2uOvRXa1Qu30fLmKhY6NipA==",
+      "requires": {
+        "readable-stream": "~1.0.2"
       }
     },
     "mimic-fn": {
@@ -790,6 +807,17 @@
         "once": "^1.3.1"
       }
     },
+    "readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -864,6 +892,11 @@
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "strip-ansi": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@types/node": "^12.0.2",
     "@types/parse5": "^5.0.0",
+    "memory-streams": "^0.1.3",
     "parse5": "^5.1.0",
     "parse5-traverse": "^1.0.3",
     "source-map-support": "^0.5.12",

--- a/src/lib/get-part-types.ts
+++ b/src/lib/get-part-types.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+import ts from 'typescript';
+import * as parse5 from 'parse5';
+const traverseHtml = require('parse5-traverse');
+
+const isTextNode = (
+  node: parse5.DefaultTreeNode
+): node is parse5.DefaultTreeTextNode => node.nodeName === '#text';
+
+const isElementNode = (
+  node: parse5.DefaultTreeNode
+): node is parse5.DefaultTreeElement => 'tagName' in node;
+
+export type PartType = 'text' | 'attribute';
+
+export const getPartTypes = (node: ts.TaggedTemplateExpression): PartType[] => {
+  const template = node.template as ts.TemplateExpression;
+  if (template.head === undefined) {
+    return [];
+  }
+
+  const marker = '{{-lit-html-}}';
+  const markerRegex = /{{-lit-html-}}/g;
+  const strings = [
+    template.head.text,
+    ...template.templateSpans.map((s) => s.literal.text),
+  ];
+  const html = strings.join(marker);
+  const fragment = parse5.parseFragment(html);
+  let partTypes: PartType[] = [];
+  traverseHtml(fragment, {
+    pre(node: parse5.DefaultTreeNode, _parent: parse5.Node) {
+      if (isTextNode(node)) {
+        const text = node.value;
+        const match = text.match(markerRegex);
+        if (match !== null) {
+          const exprCount = match.length;
+          for (let i = 0; i < exprCount; i++) {
+            partTypes.push('text');
+          }
+        }
+      } else if (isElementNode(node)) {
+        for (const attr of node.attrs) {
+          const match = attr.value.match(markerRegex);
+          if (match !== null) {
+            const exprCount = match.length;
+            for (let i = 0; i < exprCount; i++) {
+              partTypes.push('attribute');
+            }
+          }
+        }
+      }
+    },
+  });
+  return partTypes;
+};

--- a/src/lib/soy-ast.ts
+++ b/src/lib/soy-ast.ts
@@ -1,0 +1,353 @@
+/**
+ * @license
+ * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import { Writable } from 'stream';
+
+export abstract class Node {
+  abstract emit(writer: Writable): void;
+}
+
+export abstract class Expression extends Node {}
+export abstract class Command extends Node {}
+
+export class File implements Node {
+  commands: Command[];
+
+  constructor(commands: Command[]) {
+    this.commands = commands;
+  }
+
+  emit(writer: Writable) {
+    this.commands.forEach((c) => c.emit(writer));
+  }
+}
+
+export class Namespace extends Command {
+  value: string;
+
+  constructor(value: string) {
+    super();
+    this.value = value;
+  }
+
+  emit(writer: Writable) {
+    writer.write(`{namespace ${this.value}}\n`);
+  }
+}
+
+export class Template extends Command {
+  name: string;
+  commands: Command[];
+
+  constructor(name: string, commands: Command[]) {
+    super();
+    this.name = name;
+    this.commands = commands;
+  }
+
+  emit(writer: Writable) {
+    writer.write(`\n{template .${this.name}}\n`);
+    this.commands.forEach((c) => c.emit(writer));
+    writer.write(`\n{/template}\n`);
+  }
+}
+
+export class Param extends Command {
+  name: string;
+  type: string|undefined;
+
+  constructor(name: string, type: string|undefined) {
+    super();
+    this.name = name;
+    this.type = type;
+  }
+
+  emit(writer: Writable) {
+    writer.write(`  {@param ${this.name}${this.type === undefined ? '' : `: ${this.type}`}}\n`);
+  }
+}
+
+export class RawText extends Command {
+  value: string;
+
+  constructor(value: string) {
+    super();
+    this.value = value;
+  }
+
+  emit(writer: Writable) {
+    writer.write(this.value);
+  }
+}
+
+export class Print extends Command {
+  child: Expression;
+
+  constructor(child: Expression) {
+    super();
+    this.child = child;
+  }
+
+  emit(writer: Writable) {
+    writer.write('{');
+    this.child.emit(writer);
+    writer.write('}');
+  }
+}
+
+export class CallParameter extends Command {
+  name: string;
+  value: Node;
+
+  constructor(name: string, value: Node) {
+    super();
+    this.name = name;
+    this.value = value;
+  }
+
+  emit(writer: Writable) {
+    if (this.value instanceof Expression) {
+      writer.write(`{param ${this.name}}`);
+    }
+  }
+}
+
+export class CallCommand extends Command {
+  templateName: string;
+  parameters: Array<CallParameter>;
+
+  constructor(templateName: string, parameters: Array<CallParameter>) {
+    super();
+    this.templateName = templateName;
+    this.parameters = parameters;
+  }
+
+  emit(writer: Writable) {
+    const hasParameters = this.parameters.length === 0;
+    const selfClose = hasParameters ? ' /' : '';
+    writer.write(`{call .${this.templateName}${selfClose}}`);
+    this.parameters.forEach((p) => p.emit(writer));
+  }
+}
+
+export class IfCommand extends Command {
+  condition: Expression;
+  whenTrue: Command[];
+  whenFalse: Command[];
+
+  constructor(condition: Expression, whenTrue: Command[], whenFalse: Command[]) {
+    super();
+    this.condition = condition;
+    this.whenTrue = whenTrue;
+    this.whenFalse = whenFalse;
+  }
+
+  emit(writer: Writable) {
+    writer.write('\n{if ');
+    this.condition.emit(writer);
+    writer.write('}\n');
+    this.whenTrue.forEach((c) => c.emit(writer));
+    writer.write('\n{else}\n');
+    this.whenFalse.forEach((c) => c.emit(writer));
+    writer.write('\n{/if}\n');
+  }
+}
+
+export abstract class Literal extends Expression {
+  text: string;
+
+  constructor(value: string) {
+    super();
+    this.text = value;
+  }
+
+  emit(writer: Writable) {
+    writer.write(this.text);
+  }
+}
+
+export class NumberLiteral extends Literal {}
+
+export class BooleanLiteral extends Literal {}
+
+export class NullLiteral extends Literal {
+  constructor() {
+    super('null');
+  }
+}
+
+export class StringLiteral extends Literal {}
+
+export class Identifier extends Expression {
+  value: string;
+
+  constructor(value: string) {
+    super();
+    this.value = value;
+  }
+
+  emit(writer: Writable) {
+    writer.write('$');
+    writer.write(this.value);
+  }
+}
+
+export class UnaryOperator extends Expression {
+  operator: string;
+  child: Expression;
+
+  constructor(operator: string, child: Expression) {
+    super();
+    this.operator = operator;
+    this.child = child;
+  }
+
+  emit(writer: Writable) {
+    writer.write(this.operator);
+    this.child.emit(writer);
+  }
+}
+
+export class BinaryOperator extends Expression {
+  operator: string;
+  left: Expression;
+  right: Expression;
+
+  constructor(operator: string, left: Expression, right: Expression) {
+    super();
+    this.operator = operator;
+    this.left = left;
+    this.right = right;
+  }
+  
+  emit(writer: Writable) {
+    this.left.emit(writer);
+    writer.write(` ${this.operator} `);
+    this.right.emit(writer);
+  }
+}
+
+export class PropertyAccess extends Expression {
+  receiver: Expression;
+  name: string;
+
+  constructor(receiver: Expression, name: string) {
+    super();
+    this.receiver = receiver;
+    this.name = name;
+  }
+
+  emit(writer: Writable) {
+    this.receiver.emit(writer);
+    writer.write('.');
+    writer.write(this.name);
+  }
+
+}
+
+export class CallExpression extends Expression {
+  functionName: string;
+  arguments: Expression[];
+
+  constructor(functionName: string, args: Expression[]) {
+    super();
+    this.functionName = functionName;
+    this.arguments = args;
+  }
+
+  emit(writer: Writable) {
+    writer.write(this.functionName);
+    writer.write('(');
+    this.arguments.forEach((a, i) => {
+      a.emit(writer);
+      if (i < this.arguments.length - 1) {
+        writer.write(', ');
+      }
+    });
+    writer.write(')');
+  }
+}
+
+export class Empty extends Expression {
+  emit(_writer: Writable) {}
+}
+
+export class Paren extends Expression {
+  child: Expression;
+
+  constructor(child: Expression) {
+    super();
+    this.child = child;
+  }
+
+  emit(writer: Writable) {
+    writer.write('(');
+    this.child.emit(writer);
+    writer.write(')');
+  }
+}
+
+export class Index extends Expression {
+  receiver: Expression;
+  argument: Expression;
+
+  constructor(receiver: Expression, argument: Expression) {
+    super();
+    this.receiver = receiver;
+    this.argument = argument;
+  }
+
+  emit(writer: Writable) {
+    this.receiver.emit(writer);
+    writer.write('[');
+    this.argument.emit(writer);
+    writer.write(']');
+  }
+}
+
+export class Ternary {
+  condition: Expression;
+  trueExpr: Expression;
+  falseExpr: Expression;
+
+  constructor(condition: Expression, trueExpr: Expression, falseExpr: Expression) {
+    this.condition = condition;
+    this.trueExpr = trueExpr;
+    this.falseExpr = falseExpr;
+  }
+
+  emit(writer: Writable) {
+    this.condition.emit(writer);
+    writer.write(' ? ');
+    this.trueExpr.emit(writer);
+    writer.write(' : ');
+    this.falseExpr.emit(writer);
+  }
+}
+
+export class MapLiteral {
+  entries: {[key: string]: Expression | null}|null;
+
+  constructor(entries: {[key: string]: Expression | null}|null) {
+    this.entries = entries;
+  }
+}
+
+export class ListLiteral {
+  items: Array<Expression>|null;
+
+  constructor(items: Array<Expression>|null) {
+    this.items = items;
+  }
+}

--- a/src/test/lit-element_test.ts
+++ b/src/test/lit-element_test.ts
@@ -41,12 +41,12 @@ suite('grimlock', () => {
         {namespace test.ts}
         
         {template .MyElement}
-          {$param children: string}
-          <my-element>{$children}</my-element>
+          {@param children: string}
+        <my-element>{$children}</my-element>
         {/template}
         
         {template .MyElement_shadow}
-            <h1>Hello</h1>
+        <h1>Hello</h1>
         {/template}`
       );
     });

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -70,7 +70,7 @@ suite('grimlock', () => {
         assert.equal(result.diagnostics.length, 1);
         assert.include(
           result.diagnostics[0].message,
-          'template tags must be named imports'
+          'must return a TemplateResult'
         );
       });
 
@@ -150,7 +150,7 @@ suite('grimlock', () => {
           {namespace test.ts}
 
           {template .t2}
-          <div>{call .t2}</div>
+          <div>{call .t2 /}</div>
           {/template}
 
           {template .t1}
@@ -172,7 +172,7 @@ suite('grimlock', () => {
           export const t = () => html\`\${a}\`;
         `
         );
-        assert.equal(result.diagnostics.length, 1);
+        assert.isAbove(result.diagnostics.length, 0);
         assert.include(result.diagnostics[0].message, 'unknown identifier');
       });
 
@@ -212,8 +212,8 @@ suite('grimlock', () => {
         '>',
         '>=',
         '<=',
-        ['||', ' or '],
-        ['&&', ' and '],
+        ['||', 'or'],
+        ['&&', 'and'],
       ];
       for (let op of binaryOps) {
         let expected = op;
@@ -241,7 +241,7 @@ suite('grimlock', () => {
             {template .t}
               {@param a: string}
               {@param b: string}
-            {$a${expected}$b}
+            {$a ${expected} $b}
             {/template}
           `
           );
@@ -273,7 +273,13 @@ suite('grimlock', () => {
           {template .t}
             {@param yes: bool}
           
-            <div>{if $yes}<p>yes</p>{else}<p>no</p>{/if}</div>
+            <div>
+          {if $yes}
+          <p>yes</p>
+          {else}
+          <p>no</p>
+          {/if}
+          </div>
           {/template}
         `
         );
@@ -300,7 +306,7 @@ suite('grimlock', () => {
           {template .t}
             {@param yes: bool}
           
-            <div>{1+($yes?1:2)}</div>
+            <div>{1 + ($yes ? 1 : 2)}</div>
           {/template}
         `
         );

--- a/src/test/source-file-converter_test.ts
+++ b/src/test/source-file-converter_test.ts
@@ -19,7 +19,7 @@ import {convertModule, js} from './test-utils.js';
 suite('grimlock', () => {
   suite('SourceFileConverter', () => {
     test('isImportOf', () => {
-      const converter = convertModule(
+      const {converter} = convertModule(
         'test.ts',
         js`
       import {html} from 'lit-html';

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -18,6 +18,8 @@ import * as path from 'path';
 import * as fs from 'fs';
 import {stripIndentTag} from '../lib/utils.js';
 
+const {WritableStream} = require('memory-streams')
+
 export const js = stripIndentTag(true);
 export const soy = stripIndentTag(true);
 
@@ -48,8 +50,18 @@ export const convertModule = (fileName: string, source: string) => {
   //   console.log(diagnostics.map((d) => `${d.file}: ${d.messageText}`));
   // }
   const converter = new SourceFileConverter(sourceFile, checker, __dirname);
-  converter.checkFile();
-  return converter;
+  const ast = converter.convertFile();
+  const writer = new WritableStream();
+  ast.emit(writer);
+  const output = writer.toString().trim();
+  // console.log(converter.diagnostics);
+  // console.log(output);
+  return {
+    ast,
+    output,
+    diagnostics: converter.diagnostics,
+    converter,
+  };
 };
 
 const fileCache = new Map<string, string>();


### PR DESCRIPTION
Builds on #10 and fixes some of its ugliness.

This make the code a lot cleaner and separates expressions and commands via the type system so that we don’t have to implement commands by omitting the leading `{` as if they are an expression.

Sorry for the large PR. Might be easier to pair review.