### PR TITLE
Consume deep class hierarchies as input

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -687,6 +687,9 @@ export class SourceFileConverter {
             this.report(node, 'unknown class property');
             return new ast.ErrorExpression();
           }
+          if (!this.isLitElementProperty(symbol.declarations[0] as ts.PropertyDeclaration)) {
+            this.report(node, 'referenced properties must be annotated with @property()');
+            return new ast.ErrorExpression();
           }
           return new ast.Identifier(symbol.name);
         }

--- a/src/test/lit-element_test.ts
+++ b/src/test/lit-element_test.ts
@@ -141,4 +141,47 @@ describe('grimlock', () => {
       {/template}`
     );
   });
+
+  it('handles inherited properties', () => {
+    const result = convertModule(
+      'test.ts',
+      js`
+    import {LitElement, html} from 'lit-element';
+    import {customElement, property} from 'lit-element/lib/decorators.js';
+
+    class MyElementParent extends LitElement {
+      @property() bar: string;
+    }
+
+    /**
+     * @soyCompatible
+     */
+    @customElement('my-element')
+    export class MyElement extends MyElementParent {
+
+      render() {
+        return html\`<h1>Hello \${this.bar}</h1>\`;
+      }
+    }
+  `
+    );
+    expect(result.output).toEqual(
+      soy`
+      {namespace test.ts}
+      
+      {template .MyElement}
+        {@param children: string}
+        {@param bar: string}
+      <my-element>
+      {$children}
+      {call .MyElement_shadow}{param bar: $bar /}
+      {/call}</my-element>
+      {/template}
+      
+      {template .MyElement_shadow}
+        {@param bar: string}
+      <h1>Hello {$bar}</h1>
+      {/template}`
+    );
+  });
 });

--- a/src/test/lit-element_test.ts
+++ b/src/test/lit-element_test.ts
@@ -184,4 +184,31 @@ describe('grimlock', () => {
       {/template}`
     );
   });
+
+  it('errors when referenced property is not decorated with @property()', () => {
+    const result = convertModule(
+      'test.ts',
+      js`
+    import {LitElement, html} from 'lit-element';
+    import {customElement} from 'lit-element/lib/decorators.js';
+
+    /**
+     * @soyCompatible
+     */
+    @customElement('my-element')
+    export class MyElement extends LitElement {
+      bar: string;
+
+      render() {
+        return html\`<h1>Hello \${this.bar}</h1>\`;
+      }
+    }
+  `
+    );
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+    expect(result.diagnostics[0].message).toEqual('referenced properties must be annotated with @property()');
+    expect(() => {
+      result.output;
+    }).toThrow();
+  });
 });


### PR DESCRIPTION
* Allow references to inherited properties.
Implements #21

* Add error when referencing a property not marked with `@property()`.
Resolves this TODO: https://github.com/PolymerLabs/grimlock/blob/ee85271c181f08b6fdb1746a57180543b5399793/src/lib/index.ts#L693
