### PR TITLE
Properly handle boolean native attributes

### DIFF
--- a/src/lib/soy-ast.ts
+++ b/src/lib/soy-ast.ts
@@ -183,7 +183,7 @@ export class IfCommand extends Command {
     condition: Expression,
     whenTrue: Command[],
     whenFalse: Command[] = [],
-    inline: Boolean = false,
+    inline = false,
   ) {
     super();
     this.condition = condition;

--- a/src/lib/soy-ast.ts
+++ b/src/lib/soy-ast.ts
@@ -177,30 +177,35 @@ export class IfCommand extends Command {
   condition: Expression;
   whenTrue: Command[];
   whenFalse: Command[];
+  private separator: string;
 
   constructor(
     condition: Expression,
     whenTrue: Command[],
-    whenFalse: Command[]
+    whenFalse: Command[] = [],
+    inline: Boolean = false,
   ) {
     super();
     this.condition = condition;
     this.whenTrue = whenTrue;
     this.whenFalse = whenFalse;
+    this.separator = inline ? '' : '\n';
   }
 
   *emit() {
-    yield '\n{if ';
+    yield `${this.separator}{if `;
     yield* this.condition.emit();
-    yield '}\n';
+    yield `}${this.separator}`;
     for (const c of this.whenTrue) {
       yield* c.emit();
     }
-    yield '\n{else}\n';
-    for (const c of this.whenFalse) {
-      yield* c.emit();
+    if (this.whenFalse.length > 0) {
+      yield `${this.separator}{else}${this.separator}`;
+      for (const c of this.whenFalse) {
+        yield* c.emit();
+      }
     }
-    yield '\n{/if}\n';
+    yield `${this.separator}{/if}${this.separator}`;
   }
 }
 

--- a/src/lib/soy-generator.ts
+++ b/src/lib/soy-generator.ts
@@ -1051,14 +1051,18 @@ export class SoyConverter {
    * traverse and convert the type AST here. For now we'll use some simple
    * assignability checks.
    *
-   * @param node A node like a ParameterDeclaration that has a .type property.
+   * @param node A NamedDeclaration node. This will be a ParameterDeclaration
+   *     when checking the type of a parameter of a top-level lit-html
+   *     template function, or a PropertyDeclaration when checking the type
+   *     of a LitElement class property.
    */
-  getSoyTypeOfNode(node: ts.HasType): string | undefined {
-    const typeNode = node.type;
-    if (typeNode === undefined) {
+  getSoyTypeOfNode(node: ts.NamedDeclaration): string | undefined {
+    const symbol = this.checker.getSymbolAtLocation(node.name!);
+    if (symbol === undefined) {
+      this.report(node, 'unknown type');
       return undefined;
     }
-    const type = this.checker.getTypeAtLocation(typeNode);
+    const type = this.checker.getTypeOfSymbolAtLocation(symbol, node);
     const soyType = this.getSoyType(type);
     if (soyType === undefined) {
       this.report(node, 'unknown type');

--- a/src/lib/soy-generator.ts
+++ b/src/lib/soy-generator.ts
@@ -550,7 +550,21 @@ export class SoyConverter {
             }
 
             if (isBoolean) {
-              // There should be one expression.
+              // Check that the value of this attribute consists entirely of a single binding.
+              // This requirement is necessary because if the value contained anything more,
+              // the Soy AST expression would require string concatenation of text literals
+              // and expressions.
+              const containsMultipleBindings = textLiterals.length > 2;
+              const containsOtherText = textLiterals.some((literal) => literal !== '');
+              if (containsMultipleBindings || containsOtherText) {
+                this.report(
+                  templateLiteral,
+                  `boolean attribute ${name} must only contain a single expression.`
+                );
+                partTypes.push(...Array(textLiterals.length - 1).fill('attribute'));
+                continue;
+              }
+
               const booleanExpression = this.convertExpression(
                 expressions[partTypes.length],
                 scope

--- a/src/lib/soy-generator.ts
+++ b/src/lib/soy-generator.ts
@@ -545,7 +545,11 @@ export class SoyConverter {
 
             const isBound = textLiterals.length > 1;
             if (!isBound) {
-              commands.push(new ast.RawText(` ${name}="${value}"`));
+              const attrLocation = node.__location!.attrs[name.toLowerCase()];
+              // Re-slice from raw HTML to preserve exactly how the user wrote the attribute.
+              // For example, doing this respects `checked=""` and `checked`, both of which
+              // are valid HTML.
+              commands.push(new ast.RawText(` ${html.slice(attrLocation.startOffset, attrLocation.endOffset)}`));
               continue;
             }
 

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -172,7 +172,7 @@ describe('grimlock', () => {
                * @soyCompatible
                */
               export const t = () => {
-                return html\`<input disabled>\`
+                return html\`<input disabled="" checked>\`
               };
             `
           ).files[0].content
@@ -180,7 +180,7 @@ describe('grimlock', () => {
           {namespace test.ts}
 
           {template .t}
-          <input disabled="">
+          <input disabled="" checked>
           {/template}
         `);
       })

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -135,7 +135,6 @@ describe('grimlock', () => {
 
       // TODO: add test cases for
       // - `class` and `.className` on same element
-      // - input with `.value` and `.checked`
       // - `.id`, `.tabIndex`, etc.
       // - event bindings such as `.onclick`
       it('reflecting property expressions', () => {
@@ -161,6 +160,54 @@ describe('grimlock', () => {
                 {/template}
               `);
       });
+
+      it('unbound boolean attributes', () => {
+        expect(
+          grimlock.convertModule(
+            'test.ts',
+            js`
+              import {html} from 'lit-html';
+
+              /**
+               * @soyCompatible
+               */
+              export const t = () => {
+                return html\`<input disabled>\`
+              };
+            `
+          ).files[0].content
+        ).toEqual(soy`
+          {namespace test.ts}
+
+          {template .t}
+          <input disabled="">
+          {/template}
+        `);
+      })
+
+      it('special native boolean attributes set as bound properties', () => {
+        expect(
+          grimlock.convertModule(
+            'test.ts',
+            js`
+              import {html} from 'lit-html';
+
+              /**
+               * @soyCompatible
+               */
+              export const t = () => {
+                return html\`<input type="checkbox" .checked=\${true} .indeterminate="\${false}">\`
+              };
+            `
+          ).files[0].content
+        ).toEqual(soy`
+          {namespace test.ts}
+
+          {template .t}
+          <input type="checkbox" {if true}checked{/if} {if false}indeterminate{/if}>
+          {/template}
+        `);
+      })
 
       it('error on unsupported statements', () => {
         const result = grimlock.convertModule(

--- a/src/test/reflected-attribute-name_test.ts
+++ b/src/test/reflected-attribute-name_test.ts
@@ -12,22 +12,31 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {getReflectedAttributeName} from '../lib/reflected-attribute-name.js';
+import {getReflectedAttribute} from '../lib/reflected-attribute-name.js';
 
 describe('reflectedAttributeName', () => {
   it('property with same reflected name', () => {
-    expect(getReflectedAttributeName('value', 'input')).toEqual('value');
+    expect(getReflectedAttribute('value', 'input')).toEqual({
+      name: 'value',
+      isBoolean: false
+    });
   });
 
   it('property with different reflected name', () => {
-    expect(getReflectedAttributeName('className', 'input')).toEqual('class');
+    expect(getReflectedAttribute('className', 'input')).toEqual({
+      name: 'class',
+      isBoolean: false
+    });
   });
 
   it('property with no reflection', () => {
-    expect(getReflectedAttributeName('blah', 'input')).toBeUndefined();
+    expect(getReflectedAttribute('blah', 'input')).toBeUndefined();
   });
 
   it('global property', () => {
-    expect(getReflectedAttributeName('id', 'div')).toEqual('id');
+    expect(getReflectedAttribute('id', 'div')).toEqual({
+      name: 'id',
+      isBoolean: false
+    });
   });
 });


### PR DESCRIPTION
Fixes #36. Fixes #37.

Properly handle native boolean attributes when set as lit bound properties. (This also sets us up for handling Lit `?`-prefixed attributes as well, which we don't support yet).

Also, small fix for getting inferred property types for Soy template parameters (7063fc8)